### PR TITLE
Fix: Incorrect return order assignment for focal and shift in recover_focal_shift_numpy

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:conda",
+    "python-envs.defaultPackageManager": "ms-python.python:conda",
+    "python-envs.pythonProjects": []
+}

--- a/moge/utils/geometry_numpy.py
+++ b/moge/utils/geometry_numpy.py
@@ -131,7 +131,7 @@ def recover_focal_shift_numpy(points: np.ndarray, mask: np.ndarray = None, focal
         return 1., 0.
     
     if focal is None:
-        focal, shift = solve_optimal_focal_shift(uv_lr, points_lr)
+        shift, focal= solve_optimal_focal_shift(uv_lr, points_lr)
     else:
         shift = solve_optimal_shift(uv_lr, points_lr, focal)
 


### PR DESCRIPTION
Corrects the variable assignment error after calling `solve_optimal_focal_shift` when focal is initially unknown in the `recover_focal_shift_numpy` function.

The original assignment order in the code snippet was inconsistent with the expected (shift, focal) return signature:

````Python
if focal is None:
    focal, shift= solve_optimal_focal_shift(uv_lr, points_lr)
````

This fix assumes that solve_optimal_focal_shift returns (shift, focal) to ensure variables are assigned correctly and maintain consistency with the function's final return signature:

````Python
if focal is None:
    shift, focal= solve_optimal_focal_shift(uv_lr, points_lr)
````

This ensures that the return type of  `recover_focal_shift_numpy` remains consistent as (shift, focal) even when focal and shift are solved jointly.