### PR TITLE
fix(data_augmentation): correct dangling tgt_fov_max in sample_perspective absolute clamp

### DIFF
--- a/moge/utils/data_augmentation.py
+++ b/moge/utils/data_augmentation.py
@@ -34,7 +34,7 @@ def sample_perspective(
     fov_range_relative_min, fov_range_relative_max = fov_range_relative
     tgt_fov_x_min = min(fov_range_relative_min * raw_fov_x, utils3d.focal_to_fov(utils3d.fov_to_focal(fov_range_relative_min * raw_fov_y) / tgt_aspect))
     tgt_fov_x_max = min(fov_range_relative_max * raw_fov_x, utils3d.focal_to_fov(utils3d.fov_to_focal(fov_range_relative_max * raw_fov_y) / tgt_aspect))
-    tgt_fov_x_min, tgt_fov_max = max(np.deg2rad(fov_range_absolute_min), tgt_fov_x_min), min(np.deg2rad(fov_range_absolute_max), tgt_fov_x_max)
+    tgt_fov_x_min, tgt_fov_x_max = max(np.deg2rad(fov_range_absolute_min), tgt_fov_x_min), min(np.deg2rad(fov_range_absolute_max), tgt_fov_x_max)
     tgt_fov_x = rng.uniform(min(tgt_fov_x_min, tgt_fov_x_max), tgt_fov_x_max)
     tgt_fov_y = utils3d.focal_to_fov(utils3d.np.fov_to_focal(tgt_fov_x) * tgt_aspect)
 


### PR DESCRIPTION
Closes #146.

In `moge/utils/data_augmentation.py` the absolute-range clamp in `sample_perspective` reads:

```python
tgt_fov_x_min, tgt_fov_max = max(np.deg2rad(fov_range_absolute_min), tgt_fov_x_min), min(np.deg2rad(fov_range_absolute_max), tgt_fov_x_max)
tgt_fov_x = rng.uniform(min(tgt_fov_x_min, tgt_fov_x_max), tgt_fov_x_max)
```

The second LHS target is `tgt_fov_max` (typo) rather than `tgt_fov_x_max`. As a result:

1. `tgt_fov_x_max` is never overwritten, so the `np.deg2rad(fov_range_absolute_max)` clamp is silently dropped, `rng.uniform` still uses the unclamped `tgt_fov_x_max` from the preceding line.
2. `tgt_fov_max` becomes a dangling local that is never read again.

Replace `tgt_fov_max` with `tgt_fov_x_max` so the absolute upper bound is actually applied when drawing `tgt_fov_x`.

Verified against current `main` before commit, Python syntax checked via `ast.parse`. Repo ships no unit tests for this module.