### PR TITLE
Add bf16 mixed-precision inference option (--bf16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,12 @@ Options:
   --device TEXT               Device name (e.g. "cuda", "cuda:0", "cpu").
                               Defaults to "cuda"
   --fp16                      Use fp16 precision for much faster inference.
+  --bf16                      Run the ViT encoder in bf16 (weights and
+                              compute) and keep the neck, heads and refiner in
+                              fp32, i.e. the training-time mixed precision
+                              policy. Roughly halves the weight memory. v2/v3
+                              only, requires a CUDA GPU with native bf16
+                              support (Ampere or newer).
   --resize INTEGER            Resize the image(s) & output maps to a specific
                               size. Defaults to None (no resizing).
   --resolution_level INTEGER  An integer [0-9] for the resolution level for

--- a/moge/model/v2.py
+++ b/moge/model/v2.py
@@ -69,7 +69,10 @@ class MoGeModel(nn.Module):
 
     @property
     def dtype(self) -> torch.dtype:
-        return next(self.parameters()).dtype
+        # The dtype inputs are expected in. Taken from the neck rather than the first parameter, because under
+        # `enable_mixed_precision(..., cast_encoder_weights=True)` the encoder is stored in reduced precision while
+        # the neck and heads (and therefore the inputs and outputs) stay in fp32.
+        return next(self.neck.parameters()).dtype
     
     @property
     def onnx_compatible_mode(self) -> bool:
@@ -138,13 +141,21 @@ class MoGeModel(nn.Module):
             if hasattr(self, head):
                 getattr(self, head).enable_gradient_checkpointing()
 
-    def enable_mixed_precision(self, dtype: torch.dtype = torch.bfloat16):
+    def enable_mixed_precision(self, dtype: torch.dtype = torch.bfloat16, cast_encoder_weights: bool = False):
         """Enable fine-grained mixed precision: run the encoder in `dtype`, keep the neck and heads in fp32.
 
         Calling this repeatedly replaces the previous wrapping rather than stacking it.
+
+        If `cast_encoder_weights` is True, the encoder weights are also stored in `dtype`. Autocast casts them
+        to `dtype` on the fly anyway, caching the copies for the duration of the forward pass, so this does not
+        change the precision of the matmuls but roughly halves the encoder's weight memory and avoids holding
+        the weights twice. Intended for inference.
         """
         for handle in getattr(self, '_autocast_handles', []):
             handle.remove()
+
+        if cast_encoder_weights:
+            self.encoder.to(dtype)
 
         module_dtype_map = [
             (self.encoder, dtype),

--- a/moge/scripts/infer.py
+++ b/moge/scripts/infer.py
@@ -20,6 +20,8 @@ import click
 @click.option('--version', 'model_version', type=click.Choice(['v1', 'v2', 'v3']), default='v3', help='Model version. Defaults to "v3"')
 @click.option('--device', 'device_name', type=str, default='cuda', help='Device name (e.g. "cuda", "cuda:0", "cpu"). Defaults to "cuda"')
 @click.option('--fp16', 'use_fp16', is_flag=True, help='Use fp16 precision for much faster inference.')
+@click.option('--bf16', 'use_bf16', is_flag=True, help='Run the ViT encoder in bf16 (weights and compute) and keep the neck, heads and refiner in fp32, \
+i.e. the training-time mixed precision policy. Roughly halves the weight memory. v2/v3 only, requires a CUDA GPU with native bf16 support (Ampere or newer).')
 @click.option('--resize', 'resize_to', type=int, default=None, help='Resize the image(s) & output maps to a specific size. Defaults to None (no resizing).')
 @click.option('--resolution_level', type=int, default=9, help='An integer [0-9] for the resolution level for inference. \
 Higher value means more tokens and the finer details will be captured, but inference can be slower. \
@@ -41,6 +43,7 @@ def main(
     model_version: str,
     device_name: str,
     use_fp16: bool,
+    use_bf16: bool,
     resize_to: int,
     resolution_level: int,
     num_tokens: int,
@@ -86,9 +89,15 @@ def main(
         if model_version == 'v3':
             raise click.UsageError('MoGe-3 checkpoints are not released to Huggingface yet. Please provide a local path to the checkpoint.')
         pretrained_model_name_or_path = default_pretrained_models[model_version]
+    if use_bf16 and model_version == 'v1':
+        raise click.UsageError('--bf16 is only supported for v2 and v3.')
+    if use_bf16 and use_fp16:
+        raise click.UsageError('--bf16 and --fp16 are mutually exclusive.')
     model = import_model_class_by_version(model_version).from_pretrained(pretrained_model_name_or_path).to(device).eval()
     if use_fp16 and model_version != 'v3':
         model.half()
+    if use_bf16:
+        model.enable_mixed_precision(torch.bfloat16, cast_encoder_weights=True)
     
     if not any([save_maps_, save_glb_, save_ply_]):
         warnings.warn('No output format specified. Defaults to saving all. Please use "--maps", "--glb", or "--ply" to specify the output.')


### PR DESCRIPTION
## Summary

Adds an inference option that runs the ViT encoder in **bf16** while keeping the neck, heads and (for MoGe-3) the sparse refiner in **fp32** — the same fine-grained mixed precision policy `train_moge3.py --precision mixed_bf16` uses — with the encoder weights stored in bf16.

- `MoGeModel.enable_mixed_precision(dtype, cast_encoder_weights=False)` (v2/v3): new flag that also casts the encoder weights to `dtype`.
- `MoGeModel.dtype` (v2/v3) now reads the neck instead of the first parameter, so `infer()` keeps the input image and the uv grid in fp32 under mixed precision (as in training) and the refiner keeps receiving fp32 features.
- `moge infer --bf16` (v2/v3 only, mutually exclusive with `--fp16`).

## Motivation

The current `--fp16` path for v3 keeps fp32 weights and wraps the whole forward in fp16 autocast. Two consequences:

1. **Peak memory goes up, not down.** Autocast caches the fp16 copies of fp32 weights for the duration of the forward pass, so `moge-3-vitg` peaks at roughly 5.0 GB (fp32 weights) + 2.5 GB (fp16 copies) of weight memory alone. The fp32 default is 5.0 GB. This PR's option is ≈ 2.7 GB (1.14B encoder params × 2 B + 0.11B × 4 B), and there is nothing to cache because the encoder weights already are bf16.
2. The heads and the refiner run in fp16 under `--fp16`, which they never saw in training; the encoder was trained under bf16 autocast, so bf16 for the encoder and fp32 for everything else is the policy the checkpoints were trained with.

Weight memory (GB = 10⁹ bytes):

| | moge-3-vitg | moge-3-vitl | moge-2-vitl-normal |
|---|---|---|---|
| fp32 (default) | 5.00 | 1.48 | 1.32 |
| `--fp16` (fp32 weights + autocast cache, peak) | ~7.5 | ~2.2 | n/a (`.half()`) |
| `--bf16` (this PR) | 2.73 | 0.87 | 0.78 |

Numerically the matmuls see the same bf16 weights as under plain autocast; only the few fp32-policy ops (layer norms, positional-embedding interpolation) now read bf16-rounded parameters.

## Why the `dtype` property change

`infer()` does `image.to(self.dtype)`. With the encoder stored in bf16, `next(self.parameters())` is a bf16 encoder parameter, so the image and the `uv` grid would silently become bf16 (training used fp32 for both), and for v3 `torch.concat([features, uv])` would stay bf16 and mismatch the fp32 refiner. Reading the neck's dtype gives fp32 under mixed precision, fp16 after `.half()`, and fp32 for a plain model, i.e. it is unchanged for all existing code paths (`self.dtype` is only used in `infer()`).

## Validation

- CPU check on a small randomly initialised MoGe-2 model (autocast hooks redirected to `cpu` for the test): encoder parameters bf16, all other modules fp32, `model.dtype == torch.float32`, `infer()` runs end to end with fp32 outputs of the same shapes; median relative depth deviation vs. the fp32 run 2.5e-4 (bf16-level noise).
- `moge infer --help` renders the new option; `--bf16` with `--version v1` or together with `--fp16` raises a `UsageError`.
- The autocast policy itself is the one already exercised by `train_moge3.py --precision mixed_bf16`; the only new runtime code is `self.encoder.to(dtype)` and the neck-based `dtype` property.
